### PR TITLE
end-of-life: dotnet 7 it is no longer supported

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [ branch/22.08 ] # list all branches to check
+        branch: [ branch/22.08, branch/23.08 ] # list all branches to check
 
     steps:
       - uses: actions/checkout@v3

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.405" date="2024-01-09"/>
     <release version="7.0.404" date="2023-11-14"/>
     <release version="7.0.403" date="2023-10-24"/>
     <release version="7.0.402" date="2023-10-10"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.407" date="2024-03-12"/>
     <release version="7.0.406" date="2024-02-13"/>
     <release version="7.0.405" date="2024-01-09"/>
     <release version="7.0.404" date="2023-11-14"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.403" date="2023-10-24"/>
     <release version="7.0.402" date="2023-10-10"/>
     <release version="7.0.401" date="2023-09-12"/>
     <release version="7.0.400" date="2023-08-08"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.404" date="2023-11-14"/>
     <release version="7.0.403" date="2023-10-24"/>
     <release version="7.0.402" date="2023-10-10"/>
     <release version="7.0.401" date="2023-09-12"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.402" date="2023-10-10"/>
     <release version="7.0.401" date="2023-09-12"/>
     <release version="7.0.400" date="2023-08-08"/>
     <release version="7.0.306" date="2023-07-11"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.401" date="2023-09-12"/>
     <release version="7.0.400" date="2023-08-08"/>
     <release version="7.0.306" date="2023-07-11"/>
     <release version="7.0.304" date="2023-06-13"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.appdata.xml
@@ -12,6 +12,7 @@
   </description>
   <url type="homepage">https://dotnet.microsoft.com/</url>
   <releases>
+    <release version="7.0.406" date="2024-02-13"/>
     <release version="7.0.405" date="2024-01-09"/>
     <release version="7.0.404" date="2023-11-14"/>
     <release version="7.0.403" date="2023-10-24"/>

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.405/dotnet-sdk-7.0.405-linux-x64.tar.gz
-        sha256: db1f6226039313ceda561de803298fc6df0a0f34e1b214629225bb20e2c03e90
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.406/dotnet-sdk-7.0.406-linux-x64.tar.gz
+        sha256: 4c4edcf34cca191b09932d51a613de102f485ee7f6d79f31eb3695d1c526db8d
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.405/dotnet-sdk-7.0.405-linux-arm64.tar.gz
-        sha256: 83b18606c055b528856ad5642828627542d339510f33155ff126bb2522a5c68d
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.406/dotnet-sdk-7.0.406-linux-arm64.tar.gz
+        sha256: d3668d23566fbad43c98a88a44a6293ca630dfebb6d8bbae7442970652cc6b54
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.404/dotnet-sdk-7.0.404-linux-x64.tar.gz
-        sha256: f57fb1c4f2cb1fa0310a4140bab22494add5b837f43aa25380fc84f98107a0d0
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.405/dotnet-sdk-7.0.405-linux-x64.tar.gz
+        sha256: db1f6226039313ceda561de803298fc6df0a0f34e1b214629225bb20e2c03e90
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.404/dotnet-sdk-7.0.404-linux-arm64.tar.gz
-        sha256: 097b44412b10ec090ecf2716cddd6452e2c8467e67d42a9fae78264e578f61ee
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.405/dotnet-sdk-7.0.405-linux-arm64.tar.gz
+        sha256: 83b18606c055b528856ad5642828627542d339510f33155ff126bb2522a5c68d
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -1,7 +1,7 @@
 app-id: org.freedesktop.Sdk.Extension.dotnet7
-branch: '22.08'
+branch: '23.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 build-extension: true
 separate-locales: false

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.401/dotnet-sdk-7.0.401-linux-x64.tar.gz
-        sha256: 4634fa4da7ae4e3dadb83e320a87fb26f0cb12a7ca02bf9f10e6c3c1c91d645c
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.402/dotnet-sdk-7.0.402-linux-x64.tar.gz
+        sha256: 7bb331453ac01e4d76a2620b07d70301f05d88774b5219b9265e907b6b114cb1
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.401/dotnet-sdk-7.0.401-linux-arm64.tar.gz
-        sha256: 2bd42a9b966bac2d8b640ea45835294624a507942ee64b8bd502c69cf0445b46
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.402/dotnet-sdk-7.0.402-linux-arm64.tar.gz
+        sha256: 9a564a083b2e8267c01b6c37a668e7779f59d98566220719488b96a08a2ea2cc
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.400/dotnet-sdk-7.0.400-linux-x64.tar.gz
-        sha256: 35b5df21e609e4fb8cfe331999d32dc636e7ef5fc712c8e2694318e826a81746
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.401/dotnet-sdk-7.0.401-linux-x64.tar.gz
+        sha256: 4634fa4da7ae4e3dadb83e320a87fb26f0cb12a7ca02bf9f10e6c3c1c91d645c
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.400/dotnet-sdk-7.0.400-linux-arm64.tar.gz
-        sha256: 8ec9e3baf3af62a2c79c8dc6e6c4b542e2b4e85b6596beb317a80d7d914a00ca
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.401/dotnet-sdk-7.0.401-linux-arm64.tar.gz
+        sha256: 2bd42a9b966bac2d8b640ea45835294624a507942ee64b8bd502c69cf0445b46
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.402/dotnet-sdk-7.0.402-linux-x64.tar.gz
-        sha256: 7bb331453ac01e4d76a2620b07d70301f05d88774b5219b9265e907b6b114cb1
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.403/dotnet-sdk-7.0.403-linux-x64.tar.gz
+        sha256: 8a3c6bf5bfdf4f81775b7314b136bf96f0ba995804c66ae1cd787cb20365ec4e
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.402/dotnet-sdk-7.0.402-linux-arm64.tar.gz
-        sha256: 9a564a083b2e8267c01b6c37a668e7779f59d98566220719488b96a08a2ea2cc
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.403/dotnet-sdk-7.0.403-linux-arm64.tar.gz
+        sha256: 460d57c0ff651560ff7c07b03404b77cb2f72017051623dd908be38df75cf782
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.406/dotnet-sdk-7.0.406-linux-x64.tar.gz
-        sha256: 4c4edcf34cca191b09932d51a613de102f485ee7f6d79f31eb3695d1c526db8d
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.407/dotnet-sdk-7.0.407-linux-x64.tar.gz
+        sha256: e9fc112a221f0bc9a1b6dce796e0cb7f13848a252028e6ce089eb68d04376ded
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.406/dotnet-sdk-7.0.406-linux-arm64.tar.gz
-        sha256: d3668d23566fbad43c98a88a44a6293ca630dfebb6d8bbae7442970652cc6b54
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.407/dotnet-sdk-7.0.407-linux-arm64.tar.gz
+        sha256: 895c47b04863011040119c79f12fc8e38e3b556bee0aba5395ddce872d2e9551
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version

--- a/org.freedesktop.Sdk.Extension.dotnet7.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet7.yaml
@@ -16,8 +16,8 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.403/dotnet-sdk-7.0.403-linux-x64.tar.gz
-        sha256: 8a3c6bf5bfdf4f81775b7314b136bf96f0ba995804c66ae1cd787cb20365ec4e
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.404/dotnet-sdk-7.0.404-linux-x64.tar.gz
+        sha256: f57fb1c4f2cb1fa0310a4140bab22494add5b837f43aa25380fc84f98107a0d0
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
@@ -25,8 +25,8 @@ modules:
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
       - type: archive
         only-arches: [aarch64]
-        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.403/dotnet-sdk-7.0.403-linux-arm64.tar.gz
-        sha256: 460d57c0ff651560ff7c07b03404b77cb2f72017051623dd908be38df75cf782
+        url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.404/dotnet-sdk-7.0.404-linux-arm64.tar.gz
+        sha256: 097b44412b10ec090ecf2716cddd6452e2c8467e67d42a9fae78264e578f61ee
         x-checker-data:
           type: html
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version


### PR DESCRIPTION
This release has reached [end of life](https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/), meaning it is no longer supported. It's recommended to move to a supported release.